### PR TITLE
chore: strip schedule: trigger from workflows

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    # Run every Monday at 9 AM UTC
-    - cron: "0 9 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Removes the `schedule:` cron trigger from this repo's workflows.

GitHub auto-disables scheduled workflows after 60 days of no repo commits — that's what froze the base-image cascade. Weekly rebuild cadence moves to Hermes on lotor (fires `workflow_dispatch`/`repository_dispatch` at roots; existing cascade fans out from there). Removing `schedule:` makes this workflow structurally immune to `disabled_inactivity`.

Retains: `push`, `pull_request`, `repository_dispatch`, `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)